### PR TITLE
Fix NULL dereferencing in queue__node_free_cb

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -211,6 +211,14 @@ static void queue__node_free_cb(queue_node_t * node, queue_cb cb)
 
     for (uint8_t i = 0; i < QUEUE_NODE_SZ; i++)
     {
+        /* Sometimes the callback calls queue_pop, which can free the
+         * node->nodes, so we should check for NULL before dereferencing it.
+         */
+        if (node->nodes == NULL)
+        {
+            return;
+        }
+
         nd = node->nodes + i;
 
         if (nd->data != NULL)


### PR DESCRIPTION
`siridb_destroy` calls `queue_destroy` with `siridb_req_cancel` callback.

`queue__node_free_cb` checks that `nd->data != NULL` and calls `siridb_req_cancel` callback.

`siridb_req_cancel` calls `queue_pop`, which can free the `node->nodes`, so we should check that `node->nodes != NULL` before continuing the loop to avoid NULL dereferencing.

----
It was always reproducible for me in the following program: 
- Run an infinite loop: inserting 30 values every 0.02 sec (50 insertions in a second).
- Break from the loop and call `siridb_destroy`.
- As a result there was segmentation fault.